### PR TITLE
Fix message not serialized in error response

### DIFF
--- a/foundation/JRPCError.spec.ts
+++ b/foundation/JRPCError.spec.ts
@@ -1,0 +1,22 @@
+import { JRPCErrorCodes } from './constants/JRPCErrorCodes'
+import { JRPCError } from './JRPCError'
+
+describe('JRPCError', () => {
+	describe('toJSON', () => {
+		it('should include code, message and data in JSON.stringify result', () => {
+			const code = JRPCErrorCodes.INTERNAL_ERROR
+			const message = 'Something bad happened'
+			const data = { test: 'abc', xyz: 123 }
+
+			const error = new JRPCError(code, message, data)
+
+			const expectedResult = JSON.stringify({
+				code,
+				message,
+				data
+			})
+
+			expect(JSON.stringify(error)).toEqual(expectedResult)
+		})
+	})
+})

--- a/foundation/JRPCError.ts
+++ b/foundation/JRPCError.ts
@@ -10,4 +10,12 @@ export class JRPCError extends Error {
 		this.data = data
 		Object.setPrototypeOf(this, new.target.prototype) // restore prototype chain
 	}
+
+	public toJSON(): Record<string, unknown> {
+		return {
+			code: this.code,
+			message: this.message,
+			data: this.data
+		}
+	}
 }


### PR DESCRIPTION
When a `JRPCError` was returned in a response, the `message` property was not being included. Added a `toJSON` method to the error class that will serialize the error per the specs.