### PR TITLE
Fixing typescript issue with Error type

### DIFF
--- a/activities/executeRequestActivity.ts
+++ b/activities/executeRequestActivity.ts
@@ -30,10 +30,12 @@ export async function executeRequestActivity(
 			return
 		}
 	} catch (err) {
-		return {
-			jsonrpc: '2.0',
-			id: request.id,
-			error: new JRPCError(JRPCErrorCodes.INTERNAL_ERROR, err.message, err)
+		if (err instanceof Error) {
+			return {
+				jsonrpc: '2.0',
+				id: request.id,
+				error: new JRPCError(JRPCErrorCodes.INTERNAL_ERROR, err.message, err)
+			}
 		}
 	}
 }

--- a/activities/executeRequestActivity.ts
+++ b/activities/executeRequestActivity.ts
@@ -36,6 +36,12 @@ export async function executeRequestActivity(
 				id: request.id,
 				error: new JRPCError(JRPCErrorCodes.INTERNAL_ERROR, err.message, err)
 			}
+		} else {
+			return {
+				jsonrpc: '2.0',
+				id: request.id,
+				error: new JRPCError(JRPCErrorCodes.INTERNAL_ERROR)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes an issue I was having in the Time-entry project where the latest Typescript throws errors for the following reason.

The option `useUnknownInCatchVariables` becomes mandatory in newer typescript versions. It is set to `false` by default unless you have `strict` mode turned on in which case `useUnknownInCatchVariables` will be set to `true`

The only other workaround I know of is for each project using this package that has a newer typescript version to add the property: `useUnknownInCatchVariables`: `false` to their projects tsconfig.json file, this will ignore the catch error variables.

https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables

example:
https://stackoverflow.com/questions/68240884/error-object-inside-catch-is-of-type-unkown